### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fuzzywuzzy==0.17.0
+rapidfuzz==0.3.0
 gensim==3.5.0
 nltk==3.4.5
 numpy==1.14.5

--- a/src/core/build_data/build_data.py
+++ b/src/core/build_data/build_data.py
@@ -8,7 +8,7 @@ import os
 import math
 import argparse
 from itertools import count
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 from collections import defaultdict
 
 from ..utils.utils import *

--- a/src/core/utils/freebase_utils.py
+++ b/src/core/utils/freebase_utils.py
@@ -4,7 +4,7 @@ Created on Oct, 2017
 @author: hugo
 
 '''
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 
 
 def if_filterout(s):

--- a/src/core/utils/generic_utils.py
+++ b/src/core/utils/generic_utils.py
@@ -6,7 +6,7 @@ Created on Oct, 2017
 '''
 import re, string
 import numpy as np
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 from nltk.corpus import stopwords
 
 from .utils import dump_ndarray, tokenize


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy